### PR TITLE
Update index.html.erb

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -36,9 +36,9 @@
 
   <%= form_tag("dashboard", id: 'formId', method: "get") do %>
     <%= label_tag(:from, "Date from:") %>
-    <%= date_field_tag(:from, nil, placeholder: "#{Date.yesterday.to_s}") %>
+    <%= date_field_tag(:from, nil, id: 'datePick', placeholder: "#{Date.yesterday.to_s}") %>
     <%= label_tag(:from, "Date to:") %>
-    <%= date_field_tag(:to, nil, placeholder: "#{Date.tomorrow.to_s}") %>
+    <%= date_field_tag(:to, nil, id: 'datePick', placeholder: "#{Date.tomorrow.to_s}") %>
     <br><br>
     <%= submit_tag("Search", :class => 'btn btn-primary') %>
   <% end %>
@@ -46,7 +46,7 @@
 
 <script>
     $(document).on('turbolinks:load', function () {
-        $('.modal-body input').datepicker({
+      $('.modal-body input[id="datePick"]').datepicker({
             format: 'yyyy-mm-dd'
         }).on('change', function () {
             $('.datepicker').hide();


### PR DESCRIPTION
This should fix the datepicker errors that occur.  
No longer will the submit button be seen as a datepicker input field.  
This is done by assigning the datePick id to the input fields in the form and then picking them up by there id in the following line
  $('.modal-body input[id="datePick"]').datepicker({